### PR TITLE
Refactor file info retrieval for torrents

### DIFF
--- a/daemon/src/seaderr/routes/libtorrent/get_specific_files.py
+++ b/daemon/src/seaderr/routes/libtorrent/get_specific_files.py
@@ -1,19 +1,19 @@
 from pydantic import BaseModel
 
 from seaderr.decorators import validate_payload
-from seaderr.serializers import serialize_peer_info
+from seaderr.serializers import serialize_file_info
 from seaderr.singletons import SIO, LibtorrentSession
 
 sio = SIO.get_instance()
 
 
-class SpecificTorrentPeer(BaseModel):
+class SpecificTorrentFiles(BaseModel):
     info_hash: str
 
 
-@sio.on("libtorrent:get_specific_peers")  # type: ignore
-@validate_payload(SpecificTorrentPeer)
-async def get_specific_peers(sid: str, data: SpecificTorrentPeer):
+@sio.on("libtorrent:get_specific_files")  # type: ignore
+@validate_payload(SpecificTorrentFiles)
+async def get_specific_files(sid: str, data: SpecificTorrentFiles):
     ses = await LibtorrentSession.get_session()
     handles = ses.get_torrents()
 
@@ -23,11 +23,11 @@ async def get_specific_peers(sid: str, data: SpecificTorrentPeer):
 
         if str(handle.info_hash()) == data.info_hash:
             try:
-                peers_info = await serialize_peer_info(handle)
+                torrent_files = await serialize_file_info(handle)
             except Exception:
-                peers_info = []
+                torrent_files = []
 
             return {
                 "status": "success",
-                "peers": peers_info,
+                "files": torrent_files,
             }

--- a/daemon/src/seaderr/serializers/files.py
+++ b/daemon/src/seaderr/serializers/files.py
@@ -5,10 +5,8 @@ import anyio.to_thread
 import libtorrent as lt
 
 
-async def serialize_file_info(
-    handle: lt.torrent_handle, ti: lt.torrent_info
-) -> list[dict]:
-    fs = ti.files()
+async def serialize_file_info(handle: lt.torrent_handle) -> list[dict]:
+    fs = handle.get_torrent_info().files()
     num_files = fs.num_files()
 
     try:

--- a/daemon/src/seaderr/serializers/peers.py
+++ b/daemon/src/seaderr/serializers/peers.py
@@ -3,8 +3,6 @@ import libtorrent as lt
 
 from seaderr.singletons import Logger
 
-logger = Logger.get_logger()
-
 
 def infer_connection_type(flags: int) -> str:
     WEB_SEED = 1 << 31
@@ -21,6 +19,8 @@ def infer_connection_type(flags: int) -> str:
 
 
 async def serialize_peer_info(handle: lt.torrent_handle) -> list[dict]:
+    logger = Logger.get_logger()
+
     try:
         peers = handle.get_peer_info()
     except Exception as e:

--- a/daemon/src/seaderr/utilities/libtorrent/serialize_magnet_torrent_info.py
+++ b/daemon/src/seaderr/utilities/libtorrent/serialize_magnet_torrent_info.py
@@ -61,7 +61,6 @@ async def serialize_magnet_torrent_info(handle: lt.torrent_handle) -> dict:
         )
         return info
 
-    files = await serialize_file_info(handle, ti)
     nodes = [{"host": host, "port": port} for host, port in ti.nodes()]
     trackers = list(ti.trackers()) + handle.trackers()
 
@@ -80,7 +79,6 @@ async def serialize_magnet_torrent_info(handle: lt.torrent_handle) -> dict:
             "creation_date": int(ti.creation_date()),
             "num_files": int(ti.num_files()),
             "metadata_size": int(ti.metadata_size()),
-            "files": files,
             "trackers": trackers,
             "nodes": nodes,
             "url_seeds": getattr(ti, "url_seeds", lambda: [])(),

--- a/web/src/components/action-button/file-dialog.tsx
+++ b/web/src/components/action-button/file-dialog.tsx
@@ -75,7 +75,21 @@ export function FileDialog({
                         throw new Error("Info hash not found in metadata");
                     }
                     setTorrentInfoHash(infoHash);
-                    setFiles(response.metadata?.files || []);
+                    socket.current?.emit(
+                        "libtorrent:get_specific_files",
+                        {
+                            info_hash: infoHash,
+                        },
+                        (_response: {
+                            status: "error" | "success";
+
+                            files: FileInfo[];
+                        }) => {
+                            if (_response.status === "success") {
+                                setFiles(_response.files);
+                            }
+                        },
+                    );
                 } else {
                     console.error("Error fetching metadata:", response.message);
                     setMetadata(null);

--- a/web/src/components/torrent-details/peers-tab/columns.tsx
+++ b/web/src/components/torrent-details/peers-tab/columns.tsx
@@ -29,7 +29,7 @@ export const columns: ColumnDef<SyntheticPeer>[] = [
                             <TooltipTrigger asChild>
                                 <Button size="icon" variant="ghost">
                                     <CountryFlag
-                                        iso={isoValue}
+                                        iso={isoValue}  
                                         title={isoValue}
                                     />
                                 </Button>

--- a/web/src/types/socket/torrent_info.ts
+++ b/web/src/types/socket/torrent_info.ts
@@ -125,7 +125,6 @@ export interface TorrentInfo {
     connected_leeches: number;
 
     // File info
-    files: FileInfo[];
     trackers: TrackerInfo[];
     nodes: DHTNode[];
     url_seeds: string[];


### PR DESCRIPTION
Introduces a new API route to fetch specific torrent files by info hash and updates frontend to use this route. Refactors file info serialization to use torrent handle directly, removes redundant file info from magnet serialization, and cleans up related type definitions.